### PR TITLE
Ajout des options -c (create orgs) -u (update harvesters) and -v (validate harvester)

### DIFF
--- a/harvest/create-harvesters.py
+++ b/harvest/create-harvesters.py
@@ -16,6 +16,8 @@ class ApiHelper:
         url = f"{self.base_url}/api/1/organizations/{slug}/"
         headers = {'X-Fields': 'id'}
         r = session.get(url, headers=headers)
+        if r.status_code == 404:
+            return None
         r.raise_for_status()
         return r.json().get('id')
 
@@ -25,34 +27,122 @@ class ApiHelper:
         r.raise_for_status()
         return r.json().get('data', [])
 
-    def create_harvester(self, name, backend, target, org_id):
+    def create_org(self, name):
+        url = f"{self.base_url}/api/1/organizations/"
+        headers = {'Content-Type': 'application/json', 'X-API-KEY': self.token}
+        data = {
+            "name": name,
+            "description": "Ecospheres test org",
+        }
+        if not self.dry_run:
+            r = session.post(url, headers=headers, data=json.dumps(data))
+            r.raise_for_status()
+            return r.json()
+        else:
+            print('Would create organization:', json.dumps(data, indent=2))
+            return None
+
+
+    def create_harvester(self, name, backend, target, org_id, prefix=None):
         url = f"{self.base_url}/api/1/harvest/sources/"
         headers = {'Content-Type': 'application/json', 'X-API-KEY': self.token}
         data = {
             'active': True,
             'autoarchive': True,
-            'backend': backend,
             'name': name,
             'organization': {
-                'id': org_id
+                'id': org_id if org_id or not self.dry_run else '<not created in dry-run>'
             },
             'url': target
         }
+        if prefix:
+            data['config'] = {
+                'extra_configs': [
+                    {'key': 'remote_url_prefix', 'value': prefix}
+                ]
+            }
+
         if not self.dry_run:
             r = session.post(url, data=json.dumps(data), headers=headers)
             r.raise_for_status()
             return r.json()
         else:
-            print('Would create harvester:', json.dumps(data, indent=2))
+            print(f"Would create harvester:", json.dumps(data, indent=2))
             return None
+
+
+    def update_harvester(self, ident, name, target, prefix=None):
+        url = f"{self.base_url}/api/1/harvest/source/{ident}"
+        headers = {'Content-Type': 'application/json', 'X-API-KEY': self.token}
+        data = {
+            'name': name,
+            'url': target
+        }
+        if prefix:
+            data['config'] = {
+                'extra_configs': [
+                    {'key': 'remote_url_prefix', 'value': prefix}
+                ]
+            }
+
+        if not self.dry_run:
+            r = session.put(url, data=json.dumps(data), headers=headers)
+            r.raise_for_status()
+            return r.json()
+        else:
+            print(f"Would update harvester:", json.dumps(data, indent=2))
+            return None
+
+
+    def validate_harvester(self, ident):
+        if not self.dry_run:
+            url = f"{self.base_url}/api/1/harvest/source/{ident}"
+            headers = {
+                'Content-Type': 'application/json',
+                'X-API-KEY': self.token,
+                'X-Fields': 'validation{state}',
+            }
+            r = session.get(url, headers=headers)
+            r.raise_for_status()
+            validated = r.json().get("validation", {}).get("state") == "accepted"
+            if validated:
+                print("Harvester is already validated, nothing to do.")
+                return True
+        else:
+            print("Would check harvester state, then validate if needed.")
+            return None
+
+        url = f"{self.base_url}/api/1/harvest/source/{ident}/validate"
+        headers = {
+            'Content-Type': 'application/json',
+            'X-API-KEY': self.token,
+            'X-Fields': 'validation{state}',
+        }
+        data = {'state': 'accepted'}
+        if not self.dry_run:
+            r = session.post(url, data=json.dumps(data), headers=headers)
+            r.raise_for_status()
+            validated = r.json().get("validation", {}).get("state") == "accepted"
+            print(f"Harvester validation {'succeeded' if validated else 'failed'}")
+            return validated
+        else:
+            print('Would validate harvester:', json.dumps(data, indent=2))
+            return True
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('harvests', nargs='+', type=argparse.FileType('r'), metavar='config',
                         help='harvesters yaml config file(s)')
+    parser.add_argument('-c', '--create-orgs', action='store_true', default=False,
+                        help='create missing organizations')
+    parser.add_argument('-u', '--update-harvesters', action='store_true', default=False,
+                        help='update existing harvesters')
+    parser.add_argument('-v', '--validate-harvester', action='store_true', default=False,
+                        help='validate harvester right away (triggers harvesting)')
     parser.add_argument('-n', '--dry-run', action='store_true', default=False,
                         help='perform a trial run without creating harvesters')
+
     args = parser.parse_args()
 
     conf = {}
@@ -72,21 +162,45 @@ if __name__ == "__main__":
         name = endpoint['name']
         target = endpoint['url']
         org_slug = endpoint['org']
+        prefix = endpoint.get('prefix')
 
         org_id = api.get_org_id_from_slug(org_slug)
-        existing = api.get_org_harvesters(org_id)
+        org_exists = org_id is not None
+        if not org_exists:
+            print(f"Organization '{org_slug}' for '{name}' is missing")
+            if args.create_orgs:
+                o = api.create_org(org_slug)
+                org_id = o.get('id')
+                if org_id:
+                    url = f"{api_url}/fr/admin/organization/{org_id}"
+                    print(f"Created organization for '{name}': {url}")
+            else:
+                print(f"(skipping endpoint)")
+                continue
 
-        found = False
-        for e in existing:
-            if e['url'] == target:
-                u = f"{api_url}/fr/admin/harvester/{e['id']}"
-                print(f"Harvester for '{name}' already exists: {u}")
-                found = True
+        harvesters = api.get_org_harvesters(org_id) if org_exists else []
+        harvester_id = None
+        harvester_exists = False
+        for h in harvesters:
+            if h['url'] == target:
+                harvester_exists = True
+                harvester_id = h.get('id')
+                url = f"{api_url}/fr/admin/harvester/{harvester_id}"
                 break
-        if found:
-            continue
 
-        r = api.create_harvester(name, backend, target, org_id)
-        if r:
-            u = f"{api_url}/fr/admin/harvester/{r['id']}"
-            print(f"Created harvester for '{name}': {u}")
+        if harvester_exists:
+            if args.update_harvesters:
+                api.update_harvester(harvester_id, name, target, prefix=prefix)
+                print(f"Updated harvester for '{name}': {url}")
+            else:
+                print(f"Harvester for '{name}' already exists (skipping): {url}")
+        else:
+            h = api.create_harvester(name, backend, target, org_id, prefix)
+            if h:
+                harvester_id = h.get("id")
+                if harvester_id:
+                    url = f"{api_url}/fr/admin/harvester/{harvester_id}"
+                    print(f"Created harvester for '{name}': {url}")
+
+        if args.validate_harvester:
+            validated = api.validate_harvester(harvester_id)


### PR DESCRIPTION
Post-hoc PR :/ 

Déja utilisé pour déployer les moissonneurs sur demo et les mettre à jour avec le "remote_url_prefix". Cf https://github.com/ecolabdata/ecospheres/issues/357.

Il faudra à un moment mettre un peu d'ordre dans les scripts :crossed_fingers: 